### PR TITLE
feat(showcase): read groups and group attributes on menu item states

### DIFF
--- a/src/components/showcase/showcase.controller.js
+++ b/src/components/showcase/showcase.controller.js
@@ -28,17 +28,36 @@ export default class {
     childrenState = _.map(childrenState, (childState) => {
       return {
         state: childState.name,
-        name: _.get(childState, 'friendlyName', `<unnamed state: ${childState.name}>`)
+        name: _.get(childState, 'friendlyName', `<unnamed state: ${childState.name}>`),
+        groups: _.get(childState, 'groups'),
+        group: _.get(childState, 'group')
       }
     })
     return childrenState
   }
 
+  getOrderedAndGroupedChildrenState (stateName) {
+    return _.groupBy(this.getOrderedChildrenState(stateName), 'group')
+  }
+
+  getGroupsOrder (orderedAndGroupedChildrenState, groupsDetails) {
+    let keys = Object.keys(orderedAndGroupedChildrenState)
+
+    return _.orderBy(keys, groupName => {
+      return groupName === 'undefined' ? -9999 : -1 * _.get(groupsDetails, [groupName, 'weight'], 0)
+    })
+  }
+
   getSecondLevelsChildren () {
     let secondLevelsChildren = _.map(this.rootChildren, (rootChild) => {
+      const orderedAndGroupedChildrenState = this.getOrderedAndGroupedChildrenState(rootChild.state)
+      const groupsDetails = _.get(rootChild, 'groups')
+
       return [rootChild.state, {
         name: this.getSecondLevelGroupName(rootChild.state),
-        children: this.getOrderedChildrenState(rootChild.state)
+        children: orderedAndGroupedChildrenState,
+        groupsOrder: this.getGroupsOrder(orderedAndGroupedChildrenState, groupsDetails),
+        groups: groupsDetails
       }]
     })
     secondLevelsChildren = _.fromPairs(secondLevelsChildren)

--- a/src/components/showcase/showcase.html
+++ b/src/components/showcase/showcase.html
@@ -24,15 +24,21 @@
     <div class="oui-showcase__content">
       <nav class="oui-theme-sapphire oui-list oui-list_nav oui-showcase__sidenav" role="complementary" data-ng-class="{'open': $ctrl.toggle}">
         <ul class="oui-list__items">
-          <li class="oui-list__items oui-list__items_group">
-            <span class="oui-list__header" data-ng-bind="$ctrl.secondLevelsChildren[$ctrl.currentSecondLevelStateName].name"></span>
+          <li class="oui-list__items oui-list__items_group"
+              data-ng-repeat="groupKey in $ctrl.secondLevelsChildren[$ctrl.currentSecondLevelStateName].groupsOrder track by $index">
+            <span class="oui-list__header"
+                  data-ng-if="groupKey === 'undefined'"
+                  data-ng-bind="$ctrl.secondLevelsChildren[$ctrl.currentSecondLevelStateName].name"></span>
+            <span class="oui-list__header"
+                  data-ng-if="groupKey !== 'undefined'"
+                  data-ng-bind="$ctrl.secondLevelsChildren[$ctrl.currentSecondLevelStateName].groups[groupKey].name || groupKey"></span>
             <ul class="oui-list__items">
               <li class="oui-list__item"
-                  data-ng-repeat="child in $ctrl.secondLevelsChildren[$ctrl.currentSecondLevelStateName].children track by child.state"
+                  data-ng-repeat="child in $ctrl.secondLevelsChildren[$ctrl.currentSecondLevelStateName].children[groupKey] track by child.state"
                   data-ui-sref-active="oui-list__item_current">
                 <button type="button" class="oui-list__link" data-ng-click="$ctrl.onListItemClick(child.state)" data-ng-bind="child.name"></button>
               </li>
-              <li class="oui-list__item" data-ng-if="!$ctrl.secondLevelsChildren[$ctrl.currentSecondLevelStateName].children.length">
+              <li class="oui-list__item" data-ng-if="!$ctrl.secondLevelsChildren[$ctrl.currentSecondLevelStateName].groupsOrder.length">
                 No children state found under the state {{ $ctrl.currentSecondLevelStateName }}.
               </li>
             </ul>


### PR DESCRIPTION
Groups weight can be defined by adding a `groups` property to the parent state.

```javascript
.state('showcase.ovh-ui-kit', {
    url: '/ovh-ui-kit',
    friendlyName: 'ovh-ui-kit',
    groupName: 'ovh-ui-kit components',
    [...]
    groups: {
        basic: {
          name: 'Basic',
          weight: 9000
        },
        form: {
          name: 'Form',
          weight: 8000
        },
        [...]
    }
})

Item group key can be defined directly on the item state.

```javascript
.state('showcase.ovh-ui-kit.button', {
    url: '/button',
    friendlyName: 'Button',
    [...]
    group: 'basic'
})
```

You can see it running here: http://feature_groups_items_demo.ui-kit.ovh/#!/ovh-ui-kit/introduction