### PR TITLE
fix(versions): use lodash's includes for older browsers

### DIFF
--- a/src/components/versions/versions.provider.js
+++ b/src/components/versions/versions.provider.js
@@ -1,4 +1,4 @@
-import { snakeCase } from "lodash";
+import { includes, snakeCase } from "lodash";
 
 class VersionsService {
     constructor ($location, $q, $http, currentVersion) {
@@ -70,7 +70,7 @@ class VersionsService {
             .then((versions) => {
                 const formattedVersions = versions.map(snakeCase);
 
-                if (formattedVersions.includes(informations.version)) {
+                if (includes(formattedVersions, informations.version)) {
                     return versions;
                 }
 


### PR DESCRIPTION
Signed-off-by: Jimmy Fortin <jimmy.fortin@corp.ovh.com>

On IE10 and IE11 the version picker was broken:
http://fix_includes_staging.ui-kit.ovh/